### PR TITLE
Fix early use of Sheets

### DIFF
--- a/common/src/main/java/com/magistuarmory/client/render/tileentity/HeraldryItemStackRenderer.java
+++ b/common/src/main/java/com/magistuarmory/client/render/tileentity/HeraldryItemStackRenderer.java
@@ -9,10 +9,8 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.model.Model;
-import net.minecraft.client.model.geom.ModelPart;
 import net.minecraft.client.renderer.BlockEntityWithoutLevelRenderer;
 import net.minecraft.client.renderer.MultiBufferSource;
-import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.Sheets;
 import net.minecraft.client.renderer.entity.EntityRendererProvider;
 import net.minecraft.client.renderer.entity.ItemRenderer;
@@ -20,7 +18,9 @@ import net.minecraft.client.resources.model.Material;
 import net.minecraft.core.Holder;
 import net.minecraft.core.component.DataComponents;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.world.item.*;
+import net.minecraft.world.item.DyeColor;
+import net.minecraft.world.item.ItemDisplayContext;
+import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BannerPattern;
 import net.minecraft.world.level.block.entity.BannerPatternLayers;
 
@@ -29,63 +29,90 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Environment(EnvType.CLIENT)
-public class HeraldryItemStackRenderer extends BlockEntityWithoutLevelRenderer implements ShieldPatternLayer
-{
-	private Model model;
-	private final ResourceLocation location;
-	private final String patternsDirectory;
-	private final Material baseWithPatternMaterial;
-	private final Material baseWithoutPatternMaterial;
-	private final Material basePatternMaterial;
+public class HeraldryItemStackRenderer extends BlockEntityWithoutLevelRenderer implements ShieldPatternLayer {
+    private Model model;
+    private final ResourceLocation location;
+    private final MaterialContainer materialContainer;
 
-	public HeraldryItemStackRenderer(String id, ResourceLocation location)
-	{
-		super(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
-		this.location = location;
-		this.patternsDirectory = "entity/" + location.getPath() + "/";
-		this.baseWithPatternMaterial = new Material(Sheets.SHIELD_SHEET, ResourceLocation.fromNamespaceAndPath(location.getNamespace(), "entity/" + id + "_pattern"));
-		this.baseWithoutPatternMaterial = new Material(Sheets.SHIELD_SHEET, ResourceLocation.fromNamespaceAndPath(location.getNamespace(), "entity/" + id + "_nopattern"));
-		this.basePatternMaterial = new Material(Sheets.SHIELD_SHEET, ResourceLocation.fromNamespaceAndPath(this.location.getNamespace(), this.patternsDirectory + "base"));
-	}
 
-	public void loadModel(EntityRendererProvider.Context context)
-	{
-		this.model = new MedievalShieldModel(context.bakeLayer(ModModels.createLocation(this.location)));
-	}
+    public HeraldryItemStackRenderer(String id, ResourceLocation location) {
+        super(Minecraft.getInstance().getBlockEntityRenderDispatcher(), Minecraft.getInstance().getEntityModels());
+        this.location = location;
+        this.materialContainer = new MaterialContainer(id, location, "entity/" + location.getPath() + "/");
+    }
 
-	@Override
-	public void renderByItem(ItemStack stack, ItemDisplayContext transform, PoseStack pose, MultiBufferSource buffer, int p, int overlay)
-	{
-		if (this.model instanceof MedievalShieldModel shieldmodel)
-		{
-			pose.pushPose();
-			pose.scale(1.0F, -1.0F, -1.0F);
-			DyeColor basecolor = stack.get(DataComponents.BASE_COLOR);
-			VertexConsumer vertexconsumer = this.getBaseMaterial(basecolor != null).sprite().wrap(ItemRenderer.getFoilBufferDirect(buffer, this.model.renderType(this.getBaseMaterial(basecolor != null).atlasLocation()), true, stack.hasFoil()));
-			shieldmodel.handle().render(pose, vertexconsumer, p, overlay, 0xFFFFFF);
-			BannerPatternLayers patterns = stack.get(DataComponents.BANNER_PATTERNS);
-			List<Pair<Holder<BannerPattern>, DyeColor>> list = patterns == null ? new ArrayList<>() : patterns.layers().stream().map(l -> Pair.of(l.pattern(), l.color())).collect(Collectors.toList());
-			this.renderPatterns(pose, buffer, p, overlay, list, stack.hasFoil(), shieldmodel.plate(), basecolor);
+    public void loadModel(EntityRendererProvider.Context context) {
+        this.model = new MedievalShieldModel(context.bakeLayer(ModModels.createLocation(this.location)));
+    }
 
-			pose.popPose();
-		}
-	}
+    @Override
+    public void renderByItem(ItemStack stack, ItemDisplayContext transform, PoseStack pose, MultiBufferSource buffer, int p, int overlay) {
+        if (this.model instanceof MedievalShieldModel shieldmodel) {
+            pose.pushPose();
+            pose.scale(1.0F, -1.0F, -1.0F);
+            DyeColor baseColor = stack.get(DataComponents.BASE_COLOR);
+            VertexConsumer vertexconsumer = this.getBaseMaterial(baseColor != null).sprite().wrap(ItemRenderer.getFoilBufferDirect(buffer, this.model.renderType(this.getBaseMaterial(baseColor != null).atlasLocation()), true, stack.hasFoil()));
+            shieldmodel.handle().render(pose, vertexconsumer, p, overlay, 0xFFFFFF);
+            BannerPatternLayers patterns = stack.get(DataComponents.BANNER_PATTERNS);
+            List<Pair<Holder<BannerPattern>, DyeColor>> list = patterns == null ? new ArrayList<>() : patterns.layers().stream().map(l -> Pair.of(l.pattern(), l.color())).collect(Collectors.toList());
+            this.renderPatterns(pose, buffer, p, overlay, list, stack.hasFoil(), shieldmodel.plate(), baseColor);
 
-	@Override
-	public Material getBaseMaterial(boolean withPattern)
-	{
-		return withPattern ? this.baseWithPatternMaterial : this.baseWithoutPatternMaterial;
-	}
+            pose.popPose();
+        }
+    }
 
-	@Override
-	public Material getBasePatternMaterial()
-	{
-		return this.basePatternMaterial;
-	}
 
-	@Override
-	public Material getPatternMaterial(ResourceLocation patternlocation)
-	{
-		return new Material(Sheets.SHIELD_SHEET, ResourceLocation.fromNamespaceAndPath(this.location.getNamespace(), this.patternsDirectory + patternlocation.getPath()));
-	}
+    @Override
+    public Material getBaseMaterial(boolean withPattern) {
+        return withPattern ?
+                materialContainer.getBaseWithPatternMaterial() :
+                materialContainer.getBaseWithoutPatternMaterial();
+    }
+
+    @Override
+    public Material getBasePatternMaterial() {
+        return materialContainer.getBasePatternMaterial();
+    }
+
+    @Override
+    public Material getPatternMaterial(ResourceLocation patternLocation) {
+        return materialContainer.getPatternMaterial(patternLocation);
+    }
+
+    private static final class MaterialContainer {
+        private final String id;
+        private final ResourceLocation location;
+        private final String patternsDirectory;
+        private Material baseWithPatternMaterial = null;
+        private Material baseWithoutPatternMaterial = null;
+        private Material basePatternMaterial = null;
+
+        private MaterialContainer(String id, ResourceLocation location, String patternsDirectory) {
+            this.id = id;
+            this.location = location;
+            this.patternsDirectory = patternsDirectory;
+        }
+
+        public synchronized Material getBaseWithPatternMaterial() {
+            if (baseWithPatternMaterial == null)
+                baseWithPatternMaterial = new Material(Sheets.SHIELD_SHEET, ResourceLocation.fromNamespaceAndPath(location.getNamespace(), "entity/" + id + "_pattern"));
+            return baseWithPatternMaterial;
+        }
+
+        public synchronized Material getBaseWithoutPatternMaterial() {
+            if (baseWithoutPatternMaterial == null)
+                this.baseWithoutPatternMaterial = new Material(Sheets.SHIELD_SHEET, ResourceLocation.fromNamespaceAndPath(location.getNamespace(), "entity/" + id + "_nopattern"));
+            return baseWithoutPatternMaterial;
+        }
+
+        public synchronized Material getBasePatternMaterial() {
+            if (basePatternMaterial == null)
+                basePatternMaterial = new Material(Sheets.SHIELD_SHEET, ResourceLocation.fromNamespaceAndPath(this.location.getNamespace(), this.patternsDirectory + "base"));
+            return basePatternMaterial;
+        }
+
+        public Material getPatternMaterial(ResourceLocation patternLocation) {
+            return new Material(Sheets.SHIELD_SHEET, ResourceLocation.fromNamespaceAndPath(this.location.getNamespace(), this.patternsDirectory + patternLocation.getPath()));
+        }
+    }
 }


### PR DESCRIPTION
On client startup there was an exception about the early loading of the minecraft `Sheets` class caused by the use of static references from `Sheets` in the constructor of `HeraldryItemStackRenderer.` Moved the logic to create `Material` objects in a private subclass to delay the use of that `Sheets` until allowed.